### PR TITLE
Fix typo in parsing HDR10+ files

### DIFF
--- a/addon/lib/filter.js
+++ b/addon/lib/filter.js
@@ -92,8 +92,8 @@ const QualityFilter = {
     },
     {
       key: 'hdrall',
-      label: 'HDR/HRD10+/Dolby Vision',
-      items: ['HDR', 'HRD10+', 'DV'],
+      label: 'HDR/HDR10+/Dolby Vision',
+      items: ['HDR', 'HDR10+', 'DV'],
       test(quality) {
         const hdrProfiles = quality && quality.split(' ').slice(1).join() || '';
         return this.items.some(hdrType => hdrProfiles.includes(hdrType));


### PR DESCRIPTION
Hello! I noticed that `HDR10+` is misspelled as `HRD10+`. I suspect this is leading to some files being misclassified, so I wanted to suggest this fix.

I also noticed that some torrents have `HDR10Plus` in their names rather than the `+` sign, for example: `Star.Trek.Strange.New.Worlds.S02E05.Sciarada.2160p.DVHDR10Plus.HEVC.WEBDL.AC3.ITA.ENG.SUB.G66.mkv`. It might be a good idea to add `HDR10Plus` to this parser.

Thanks for all your hard work!