### PR TITLE
Minor catalog meta improvements for Put.io

### DIFF
--- a/addon/moch/putio.js
+++ b/addon/moch/putio.js
@@ -54,6 +54,7 @@ export async function getItemMeta(itemId, apiKey) {
               id: `${KEY}:${file.id}:${index}`,
               title: file.name,
               released: new Date(file.created_at).toISOString(),
+              thumbnail: file.screenshot,
               streams: [{ url: `${apiKey}/null/null/${file.id}` }]
             }))
       }))

--- a/addon/moch/putio.js
+++ b/addon/moch/putio.js
@@ -36,7 +36,8 @@ export async function getCatalog(apiKey, offset = 0) {
           .map(file => ({
             id: `${KEY}:${file.id}`,
             type: Type.OTHER,
-            name: file.name
+            name: file.name,
+            posterShape: 'landscape'
           })));
 }
 


### PR DESCRIPTION
* Add `thumbnail` to catalog item videos (where available from Put.io).
Example:

<img width="969" alt="Screenshot 2024-01-07 144940" src="https://github.com/TheBeastLT/torrentio-scraper/assets/2302043/451396e8-dc87-4edb-b906-e53232798f47">


* Set poster shape to `landscape` to make file names more readable.
Example:

<img width="973" alt="image" src="https://github.com/TheBeastLT/torrentio-scraper/assets/2302043/3041e3df-669f-46e1-9198-f1d15a6e730f">
