### PR TITLE
Added tracker backup URL, 'Smart' torrent sort option, bumped version

### DIFF
--- a/addon/lib/manifest.js
+++ b/addon/lib/manifest.js
@@ -11,7 +11,7 @@ export function manifest(config = {}) {
   const overrideManifest = getManifestOverride(config);
   const baseManifest = {
     id: 'com.stremio.torrentio.addon',
-    version: '0.0.14',
+    version: '0.0.15',
     name: getName(overrideManifest, config),
     description: getDescription(config),
     catalogs: getCatalogs(config),

--- a/addon/lib/sort.js
+++ b/addon/lib/sort.js
@@ -76,7 +76,7 @@ function sortByPoints(streams, limit) {
   return streams
     .map(stream => {
       const seedersScore = extractSeeders(stream.title) * WEIGHTS.seeders;
-      const sizeScore = extractSize(stream.title) * WEIGHTS.size;
+      const sizeScore = extractSize(stream.title)/1000000000 * WEIGHTS.size; //in GB
       const qualityScore = getQualityScore(stream) * WEIGHTS.quality;
       const totalScore = seedersScore * (qualityScore/sizeScore); // seeders * (quality/size)
       return { ...stream, totalScore };
@@ -87,10 +87,10 @@ function sortByPoints(streams, limit) {
 
 function getQualityScore(stream) {
   const quality = extractQuality(stream.name);
-  if (/8k/i.test(quality)) return 5; // highest score for 8k
-  if (/4k|uhd/i.test(quality)) return 4;
-  if (quality.match(/\d+p/)) return parseInt(quality, 10) / 1000; // scale resolution to score
-  if (CAM_QUALITIES.test(quality)) return 0.1; // low score for cam quality
+  if (quality.match(/8k/i)) return 4; // highest score for 8k
+  if (quality.match(/(2060p|2160p|4k)/i)) return 2.5;
+  if (quality.match(/\d+p/)) return Math.pow(parseInt(quality, 10) / 1000, 2.5); // scale resolution to score, pow to make scores exponential
+  if (CAM_QUALITIES.test(quality)) return 0.1; // low score for CAM quality
   if (OTHER_QUALITIES.test(quality)) return 0.2;
   return 1; // fallback score
 }


### PR DESCRIPTION
Hi @TheBeastLT!

I've added two things here–first is a backup tracker URL in case the GitHub one goes down. Right now it just gets the most recent snapshot off Wayback Machine, but in a distant future where the GitHub link gets taken down it would make more sense to freeze it at a specific snapshot. Just something to note.

Additionally, I added functionality for a 'Smart' sorting option, which ranks streams with the formula `Seeders * Quality/Size`. It's not perfect, but I've also laid a little groundwork for user-customized sorting, which will be a nice addition for all. 

Do note these changes are _untested_ because I have no way to spin up the DB side, despite my best efforts. 