### PR TITLE
Update languages.js

### DIFF
--- a/addon/lib/filter.js
+++ b/addon/lib/filter.js
@@ -68,12 +68,17 @@ export const Providers = {
     {
       key: 'comando',
       label: 'Comando',
-      foreign: '🇵🇹'
+      foreign: '🇧🇷'
     },
     {
       key: 'bludv',
       label: 'BluDV',
-      foreign: '🇵🇹'
+      foreign: '🇧🇷'
+    },
+    {
+      key: 'micoLeaoDublado',
+      label: 'MicoLeaoDublado',
+      foreign: '🇧🇷'
     },
     {
       key: 'torrent9',

--- a/addon/lib/languages.js
+++ b/addon/lib/languages.js
@@ -7,7 +7,7 @@ const languageMapping = {
   'japanese': '🇯🇵',
   'russian': '🇷🇺',
   'italian': '🇮🇹',
-  'portuguese': '🇵🇹',
+  'portuguese': '🇧🇷',
   'spanish': '🇪🇸',
   'latino': '🇲🇽',
   'korean': '🇰🇷',


### PR DESCRIPTION
Need to replace the emoji "🇵🇹" with "🇧🇷", for the 2 Portuguese speaking trackers available (Comando and BluDV) are Brazilian.
Edit: Also, Portugal has a population of 10 million, while Brazil has a population of 210 million. For phonetic reasons, Brazilians have a hard time understanding the accent of Portuguese people, so Brazilian users may think that the media is dubbed in that accent and don't even click to open that version of the media.