### PR TITLE
Add multi-signal Polish release detection (#359)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Torrentio
 
 - [torrentio-addon](addon) - the Stremio addon which will query scraped entries and return Stremio stream results.
+
+## Docs
+
+- [Polish release detection](addon/docs/polish-detection.md) - how Polish releases are detected, labeled and prioritized.

--- a/addon/docs/polish-detection.md
+++ b/addon/docs/polish-detection.md
@@ -22,10 +22,11 @@ module that scores a release/file name against multiple signals:
 | `napisy-pl` | 4 | `Napisy PL`, bare `Napisy`, `PLSUB`, `SUBPL` |
 | `language-tag` | 4 | standalone `PL` / `POL` token (`www.site.PL` excluded) |
 | `polish-word` | 4 | `POLISH`, `polski`, `po polsku` (skipped as the first word, e.g. the movie "Polish Wedding") |
-| `polish-phrase` | 3 | `cały film`, `odcinek` |
+| `polish-phrase` | 3 | `cały film`, `odcinek`/`odc`, `paczka`, `kolekcja`, `miniserial`, `wersja` |
 | `polish-site` | 3 | tracker watermarks: `ex-torrenty`, `devil-torrents`, `polskie-torrenty`, `electro-torrent`... |
 | `polish-diacritics` | 3 | letters unique to the Polish alphabet: `ą ć ę ł ń ś ź ż` |
-| `release-group` | 2 | curated Polish groups: `K83`, `B89`, `KiT`, `PSiG`, `DSiTE`, `NitroTeam` |
+| `release-group` | 2 | ~70 curated Polish groups (`K83`, `B89`, `KiT`, `PSiG`, `ANONiM`, `LTS`...), based on regex sets shared by the Polish Stremio community; generic/international tokens (`FLAME`, `FOX`, `KDE`, bare `K`...) deliberately excluded |
+| `polish-uploader` | 2 | known Polish uploader handles (`spajk85`, `agusiq`, `marcin0313`...) |
 | `polish-domain` | 2 | any `*.pl` domain in the name |
 | `polish-provider` | 2 | torrent scraped from a Polish provider (`BestTorrents`) |
 | `sezon` | 1 | `Sezon` (weak — also used by Turkish releases) |

--- a/addon/docs/polish-detection.md
+++ b/addon/docs/polish-detection.md
@@ -1,0 +1,143 @@
+# Polish release detection
+
+Improves detection and labeling of Polish releases (requested in
+[#359](https://github.com/TheBeastLT/torrentio-scraper/issues/359)).
+
+A lot of Polish releases on general trackers (1337x, TPB, TorrentGalaxy) and
+Polish MULTi releases are not tagged `PL`/`POLISH`, so `parse-torrent-title`
+does not report `polish` for them. As a result they don't get the 🇵🇱 flag in
+stream titles and are not prioritized when the user selects Polish as their
+priority language. The most common community complaint is MULTi releases with
+Polish audio not being recognized as Polish.
+
+## How it works
+
+[`lib/polishDetection.js`](../lib/polishDetection.js) is a dependency-free
+module that scores a release/file name against multiple signals:
+
+| Signal | Score | Example |
+|---|---|---|
+| `lektor` | 4 | `Lektor PL`, `Lektor IVO`, bare `Lektor` |
+| `dubbing-pl` | 4 | `Dubbing PL`, `PLDUB`, `PL.DUB`, `DUBPL` |
+| `napisy-pl` | 4 | `Napisy PL`, bare `Napisy`, `PLSUB`, `SUBPL` |
+| `language-tag` | 4 | standalone `PL` / `POL` token (`www.site.PL` excluded) |
+| `polish-word` | 4 | `POLISH`, `polski`, `po polsku` (skipped as the first word, e.g. the movie "Polish Wedding") |
+| `polish-phrase` | 3 | `cały film`, `odcinek` |
+| `polish-site` | 3 | tracker watermarks: `ex-torrenty`, `devil-torrents`, `polskie-torrenty`, `electro-torrent`... |
+| `polish-diacritics` | 3 | letters unique to the Polish alphabet: `ą ć ę ł ń ś ź ż` |
+| `release-group` | 2 | curated Polish groups: `K83`, `B89`, `KiT`, `PSiG`, `DSiTE`, `NitroTeam` |
+| `polish-domain` | 2 | any `*.pl` domain in the name |
+| `polish-provider` | 2 | torrent scraped from a Polish provider (`BestTorrents`) |
+| `sezon` | 1 | `Sezon` (weak — also used by Turkish releases) |
+
+`MULTi` alone is **not** a Polish signal (limits false positives), but it adds
++1 when at least one weak Polish signal (score ≥ 2) is present, because Polish
+groups/trackers tag releases with Polish audio + original audio as `MULTi`.
+
+The summed score maps to a confidence level instead of a bare boolean:
+
+| Confidence | Score | `isPolish` |
+|---|---|---|
+| `high` | ≥ 4 | yes |
+| `medium` | ≥ 3 | yes |
+| `low` | ≥ 1 | no |
+| `none` | 0 | no |
+
+```js
+import { detectPolishRelease } from './lib/polishDetection.js';
+
+detectPolishRelease('Diuna.Czesc.Druga.2024.MULTi.1080p.BluRay.x264-KiT');
+// {
+//   isPolish: true, confidence: 'medium', score: 3,
+//   signals: ['release-group', 'multi-corroboration'],
+//   tags: { lektor: false, dubbing: false, napisy: false, multi: true }
+// }
+```
+
+`tags` additionally classifies the type of Polish audio (lektor / dubbing /
+napisy / multi), which integrators can surface in the UI.
+
+### Integration
+
+`lib/streamInfo.js#getLanguages` appends `polish` to the detected languages
+when the module reports `isPolish` (confidence `medium` or higher) for either
+the torrent title or the file title. This automatically:
+
+- shows the 🇵🇱 flag in the stream description,
+- makes the existing `language=polish` priority sorting (`lib/sort.js`) and
+  the language filter work for these releases.
+
+No changes to scrapers, the database or the API are required. The module is
+self-contained so it can be reused by companion projects (Jackettio,
+AIOStreams, Torznab bridges).
+
+## Running tests
+
+Tests use the built-in `node:test` runner (no new dependencies, Node ≥ 18)
+and run fully offline against fixtures in
+[`test/fixtures/polishReleases.json`](../test/fixtures/polishReleases.json):
+
+```sh
+cd addon
+npm install
+npm test
+```
+
+To try the detector on a single name without a database:
+
+```sh
+node --input-type=module -e "import('./lib/polishDetection.js').then(m => console.log(m.detectPolishRelease(process.argv[1])))" "Kler.2018.PL.1080p.WEB-DL.x264-PSiG"
+```
+
+## Running the addon locally
+
+The addon serves entries from an already scraped PostgreSQL database
+(the scraper code is not part of this repository):
+
+```sh
+cd addon
+npm install
+DATABASE_URI=postgres://user:password@localhost:5432/torrentio npm start
+# addon available at http://localhost:7000
+```
+
+Or via Docker:
+
+```sh
+cd addon
+docker build -t torrentio-addon .
+docker run -p 7000:7000 -e DATABASE_URI=postgres://user:password@host:5432/torrentio torrentio-addon
+```
+
+Optional env vars: `PORT` (default `7000`), `CACHE_MAX_AGE` (seconds),
+`METRICS_USER`/`METRICS_PASSWORD` (swagger-stats auth), `MONGODB_URI`/`REDIS_URI`
+(cache backends, in-memory cache is used when not set).
+
+## Polish source candidates (status as of 2026-06)
+
+Adding new scraped sources is not possible in this repository (scrapers are
+private), so the practical path for more Polish content is Jackett/Prowlarr
+(both have indexer definitions for the trackers below) combined with
+Torznab-based addons (Jackettio, AIOStreams) — this detection module mirrors
+what those projects need to prioritize Polish streams. Quick assessment:
+
+| Source | Reachable | Notes |
+|---|---|---|
+| best-torrents.net | already scraped | the only Polish provider in Torrentio (`BestTorrents`) |
+| ex-torrenty.org | yes (HTTPS) | account required for download links; same engine family as best-torrents |
+| polskie-torrenty.eu | yes (HTTPS) | community-recommended for 4K; questionable seed counts |
+| electro-torrent.pl | yes (HTTPS) | account required |
+| devil-torrents.pl | yes (HTTPS) | account required |
+| xtorrenty.org | yes (HTTPS) | account required |
+| helltorrents.com | **403** | anti-bot protection, bad scraping candidate |
+| pte.nu, rstorrent.org.pl, torrentleech.pl, cinemamovies.pl, exitorrent.org | private | invite/login only, not viable for a public scraper |
+
+## Known limitations
+
+- `polish-word` only skips a leading `Polish ...` — an English title containing
+  "Polish" mid-name would still match.
+- `ć` is shared with Croatian/Serbian, so a Croatian title using `ć` (and no
+  other unique Polish letters) could score `medium`.
+- The Polish release-group list is intentionally small and conservative;
+  extend `POLISH_GROUPS` in `lib/polishDetection.js` as new groups appear.
+- Detection runs on names only — it cannot verify actual audio tracks.

--- a/addon/lib/polishDetection.js
+++ b/addon/lib/polishDetection.js
@@ -1,0 +1,107 @@
+// Multi-signal detection of Polish releases based on the torrent/file name.
+// parse-torrent-title already handles explicit tags (PL, POLISH, Lektor PL...),
+// but a lot of Polish releases on general trackers are only identifiable by
+// weaker signals (release group, MULTi + Polish context, diacritics, tracker
+// watermarks). This module combines those signals into a confidence score so
+// integrators can pick their own precision/recall trade-off.
+// It is intentionally dependency free, so it can be reused outside the addon.
+
+export const Confidence = {
+  NONE: 'none',
+  LOW: 'low',
+  MEDIUM: 'medium',
+  HIGH: 'high'
+};
+
+const MEDIUM_SCORE = 3;
+const HIGH_SCORE = 4;
+
+// Polish specific audio/subtitle tags. A bare "Lektor" or "Napisy" is already
+// uniquely Polish, while "Dubbing"/"DUB" alone is generic and needs the PL part.
+const LEKTOR_REGEX = /\blektor\b/i;
+const DUBBING_REGEX = /\b(?:dubbing[ ._-]*PL|PL[ ._-]?DUB(?:BING)?|DUB[ ._-]?PL)\b/i;
+const NAPISY_REGEX = /\b(?:napisy|PL[ ._-]?SUB(?:BED|S)?|SUB(?:S|BED)?[ ._-]?PL)\b/i;
+// Same guard as parse-torrent-title uses, so "www.site.PL" prefixes don't match.
+const LANGUAGE_TAG_REGEX = /(?<!w{3}\.\w+\.)\b(?:PL|POL)\b/i;
+// skipped when it is the first word, since then it's likely part of the title,
+// e.g. "Polish Wedding (1998)".
+const POLISH_WORD_REGEX = /\b(?:polish|polski(?:e|ego)?|po[ ._-]polsku|film[ ._-]polski)\b/i;
+const MULTI_REGEX = /\bMULTi?\b/i;
+// Curated list of release groups publishing Polish/MULTi-with-Polish releases.
+// Case sensitive on purpose, to not match unrelated words like "kit".
+const POLISH_GROUPS = ['K83', 'B89', 'KiT', 'PSiG', 'DSiTE', 'NitroTeam'];
+const POLISH_GROUP_REGEX = new RegExp(`(?:^|[ .([\\]-])(?:${POLISH_GROUPS.join('|')})(?:$|[ .)\\][-])`);
+// Polish tracker watermarks frequently embedded in release/file names.
+const POLISH_SITE_REGEX = /best-?torrents|ex-?torrenty|devil-?torrents|polskie-?torrenty|electro-?torrent|helltorrents|xtorrenty|cinemamovies|exitorrent/i;
+const POLISH_DOMAIN_REGEX = /\b[a-z0-9-]+\.pl\b/i;
+// Letters unique to the Polish alphabet ("ó" is shared with other languages).
+const POLISH_DIACRITICS_REGEX = /[ąćęłńśźż]/i;
+const POLISH_PHRASE_REGEX = /\bca[łl]y[ ._-]*film\b|\bodcinek\b/i;
+const SEZON_REGEX = /\bsezon\b/i; // also used by Turkish releases, so a weak signal
+const POLISH_PROVIDERS = ['besttorrents'];
+
+const SIGNALS = [
+  { name: 'lektor', score: 4, test: name => LEKTOR_REGEX.test(name) },
+  { name: 'dubbing-pl', score: 4, test: name => DUBBING_REGEX.test(name) },
+  { name: 'napisy-pl', score: 4, test: name => NAPISY_REGEX.test(name) },
+  { name: 'language-tag', score: 4, test: name => LANGUAGE_TAG_REGEX.test(name) },
+  { name: 'polish-word', score: 4, test: name => isPolishWordMatch(name) },
+  { name: 'polish-phrase', score: 3, test: name => POLISH_PHRASE_REGEX.test(name) },
+  { name: 'polish-site', score: 3, test: name => POLISH_SITE_REGEX.test(name) },
+  { name: 'polish-diacritics', score: 3, test: name => POLISH_DIACRITICS_REGEX.test(name) },
+  { name: 'release-group', score: 2, test: name => POLISH_GROUP_REGEX.test(name) },
+  { name: 'polish-domain', score: 2, test: name => POLISH_DOMAIN_REGEX.test(name) },
+  { name: 'polish-provider', score: 2, test: (name, provider) => isPolishProvider(provider) },
+  { name: 'sezon', score: 1, test: name => SEZON_REGEX.test(name) }
+];
+
+export function detectPolishRelease(name, options = {}) {
+  const input = name || '';
+  const signals = SIGNALS
+      .filter(signal => signal.test(input, options.provider))
+      .map(signal => ({ name: signal.name, score: signal.score }));
+  let score = signals.reduce((total, signal) => total + signal.score, 0);
+  const multi = MULTI_REGEX.test(input);
+  if (multi && score >= 2 && score < HIGH_SCORE) {
+    // MULTi alone is not a Polish signal, but it corroborates weaker ones,
+    // since Polish groups/trackers tag Polish audio + original audio as MULTi.
+    signals.push({ name: 'multi-corroboration', score: 1 });
+    score += 1;
+  }
+  const confidence = toConfidence(score);
+  return {
+    isPolish: score >= MEDIUM_SCORE,
+    confidence: confidence,
+    score: score,
+    signals: signals.map(signal => signal.name),
+    tags: {
+      lektor: LEKTOR_REGEX.test(input),
+      dubbing: DUBBING_REGEX.test(input),
+      napisy: NAPISY_REGEX.test(input),
+      multi: multi
+    }
+  };
+}
+
+function isPolishWordMatch(name) {
+  const match = name.match(POLISH_WORD_REGEX);
+  // a leading "Polish ..." is most likely part of the actual title
+  return !!match && match.index > 0;
+}
+
+function isPolishProvider(provider) {
+  return !!provider && POLISH_PROVIDERS.includes(provider.toLowerCase().replace(/[^a-z0-9]/g, ''));
+}
+
+function toConfidence(score) {
+  if (score >= HIGH_SCORE) {
+    return Confidence.HIGH;
+  }
+  if (score >= MEDIUM_SCORE) {
+    return Confidence.MEDIUM;
+  }
+  if (score >= 1) {
+    return Confidence.LOW;
+  }
+  return Confidence.NONE;
+}

--- a/addon/lib/polishDetection.js
+++ b/addon/lib/polishDetection.js
@@ -18,25 +18,46 @@ const HIGH_SCORE = 4;
 
 // Polish specific audio/subtitle tags. A bare "Lektor" or "Napisy" is already
 // uniquely Polish, while "Dubbing"/"DUB" alone is generic and needs the PL part.
-const LEKTOR_REGEX = /\blektor\b/i;
-const DUBBING_REGEX = /\b(?:dubbing[ ._-]*PL|PL[ ._-]?DUB(?:BING)?|DUB[ ._-]?PL)\b/i;
-const NAPISY_REGEX = /\b(?:napisy|PL[ ._-]?SUB(?:BED|S)?|SUB(?:S|BED)?[ ._-]?PL)\b/i;
+const LEKTOR_REGEX = /\blektor(?:pl)?\b/i;
+const DUBBING_REGEX = /\b(?:dubbing[ ._-]*PL|dubbingpl|PL[ ._-]?DUB(?:BING)?|DUB(?:B|BING)?[ ._-]?PL)\b/i;
+const NAPISY_REGEX = /\b(?:napisy(?:pl)?|napiproje?kt|PL[ ._-]?SUB(?:BED|S)?|SUB(?:S|BED)?[ ._-]?PL)\b/i;
 // Same guard as parse-torrent-title uses, so "www.site.PL" prefixes don't match.
 const LANGUAGE_TAG_REGEX = /(?<!w{3}\.\w+\.)\b(?:PL|POL)\b/i;
 // skipped when it is the first word, since then it's likely part of the title,
 // e.g. "Polish Wedding (1998)".
 const POLISH_WORD_REGEX = /\b(?:polish|polski(?:e|ego)?|po[ ._-]polsku|film[ ._-]polski)\b/i;
 const MULTI_REGEX = /\bMULTi?\b/i;
-// Curated list of release groups publishing Polish/MULTi-with-Polish releases.
+// Curated list of release groups publishing Polish/MULTi-with-Polish releases,
+// based on regex sets shared by the Polish Stremio community. Generic words,
+// international groups and one-letter tokens were dropped on purpose
+// (e.g. FLAME, FOX, GUN, KDE, R2D2, DReaM, bare K) to limit false positives.
 // Case sensitive on purpose, to not match unrelated words like "kit".
-const POLISH_GROUPS = ['K83', 'B89', 'KiT', 'PSiG', 'DSiTE', 'NitroTeam'];
+const POLISH_GROUPS = [
+  'A4O', 'ABM', 'AFO', 'AL3X', 'ANONiM', 'AS76', 'AZQ', 'Alusia', 'B2RPL', 'B89', 'BEBLU', 'BODZiO',
+  'BP007', 'BiDA', 'BiRD', 'CAMBiO', 'CHOPiN', 'CZRG', 'ChrisVPS', 'CiNEMAET', 'CinemaPolish', 'CoLO',
+  'DENDA', 'DSiTE', 'DYZIO', 'DZiDEK', 'DeiX', 'EMiS', 'EnTeR1973', 'FARNA', 'FPL', 'Flipu', 'GHW',
+  'GLiMMER', 'GR4PE', 'GameToonHD', 'GarRipzone', 'H3Q', 'HDBEE', 'HMDb', 'Izyk', 'JASKIER', 'Japhson',
+  'K041', 'K83', 'KIFR', 'KLiO', 'KPFR', 'KSQ', 'Kbuso', 'KiKO', 'KiT', 'KilKr', 'LTN', 'LTS', 'MAXiM',
+  'MORS', 'MiNS', 'Mixio', 'N0B0DY', 'N0L4', 'NitroTeam', 'NoNaNo', 'ODiSON', 'OzW', 'PIXELPOLICE',
+  'PLHD', 'PSOTNIK', 'PSiG', 'PTRG', 'PTTrG', 'PdlG', 'PiratesZone', 'ProPLTV', 'RAVoD', 'Ralf',
+  'RobSil', 'SK13', 'SYRIX', 'SZAFQU', 'Speedboy', 'Spedboy', 'StarLordX', 'TFSH', 'TV4TG', 'TiTaNiUM',
+  'ToP2P', 'WEB4TG', 'WiZARDS', 'XuploaD', 'ZLOCiUTKi', 'alE13', 'd666', 'inTGrity', 'wzrtyk', 'xmatr1x'
+];
 const POLISH_GROUP_REGEX = new RegExp(`(?:^|[ .([\\]-])(?:${POLISH_GROUPS.join('|')})(?:$|[ .)\\][-])`);
+// Known Polish uploader handles appearing in release/file names.
+const POLISH_UPLOADERS = [
+  'agusiq', 'dabrjarek', 'elladajarek', 'fiona9', 'gamer158', 'joanna668', 'kamil445', 'kamil11124',
+  'lufen', 'lysol1', 'maksim80', 'marcin0313', 'marjos83', 'nicollubin', 'pcela', 'potroks', 'spajk85',
+  'sy5ka', 'taboon1', 'tokar86a', 'wasik', 'wilu75', 'wosiu', 'zyvela'
+];
+const POLISH_UPLOADER_REGEX = new RegExp(`\\b(?:${POLISH_UPLOADERS.join('|')})\\b`, 'i');
 // Polish tracker watermarks frequently embedded in release/file names.
-const POLISH_SITE_REGEX = /best-?torrents|ex-?torrenty|devil-?torrents|polskie-?torrenty|electro-?torrent|helltorrents|xtorrenty|cinemamovies|exitorrent/i;
+const POLISH_SITE_REGEX = /best-?torrents|ex-?torrenty|devil-?torrents|polskie-?torrenty|electro-?torrent|helltorrents|xtorrenty|cinemamovies|exitorrent|polishtorrent|cool-?torents|shadows-?torrents|torrentmaniak|topfilmyfilmweb|bigbbs|filetracker|ekipa[ ._-]tnt/i;
 const POLISH_DOMAIN_REGEX = /\b[a-z0-9-]+\.pl\b/i;
 // Letters unique to the Polish alphabet ("ó" is shared with other languages).
 const POLISH_DIACRITICS_REGEX = /[ąćęłńśźż]/i;
-const POLISH_PHRASE_REGEX = /\bca[łl]y[ ._-]*film\b|\bodcinek\b/i;
+// Polish words characteristic for Polish uploads.
+const POLISH_PHRASE_REGEX = /\bca[łl]y[ ._-]*film\b|\bodc(?:inek|inki)?\b|\bpaczka\b|\bkolekcja\b|\bminiserial\b|\brekonstrukcja\b|\bwersja\b/i;
 const SEZON_REGEX = /\bsezon\b/i; // also used by Turkish releases, so a weak signal
 const POLISH_PROVIDERS = ['besttorrents'];
 
@@ -50,6 +71,7 @@ const SIGNALS = [
   { name: 'polish-site', score: 3, test: name => POLISH_SITE_REGEX.test(name) },
   { name: 'polish-diacritics', score: 3, test: name => POLISH_DIACRITICS_REGEX.test(name) },
   { name: 'release-group', score: 2, test: name => POLISH_GROUP_REGEX.test(name) },
+  { name: 'polish-uploader', score: 2, test: name => POLISH_UPLOADER_REGEX.test(name) },
   { name: 'polish-domain', score: 2, test: name => POLISH_DOMAIN_REGEX.test(name) },
   { name: 'polish-provider', score: 2, test: (name, provider) => isPolishProvider(provider) },
   { name: 'sezon', score: 1, test: name => SEZON_REGEX.test(name) }

--- a/addon/lib/streamInfo.js
+++ b/addon/lib/streamInfo.js
@@ -1,6 +1,7 @@
 import titleParser from 'parse-torrent-title';
 import { Type } from './types.js';
 import { mapLanguages } from './languages.js';
+import { detectPolishRelease } from './polishDetection.js';
 import { enrichStreamSources, getSources } from './magnetHelper.js';
 import { getSubtitles } from './subtitles.js';
 
@@ -74,6 +75,9 @@ function getLanguages(record, torrentInfo, fileInfo) {
   const fileLanguages = fileInfo.languages || [];
   const dubbed = torrentInfo.dubbed || fileInfo.dubbed;
   let languages = Array.from(new Set([].concat(torrentLanguages).concat(fileLanguages).concat(providerLanguages)));
+  if (!languages.includes('polish') && isPolishRelease(record)) {
+    languages = languages.concat('polish');
+  }
   if (record.kitsuId || record.torrent.type === Type.ANIME) {
     // no need to display japanese for anime
     languages = languages.concat(dubbed ? ['dubbed'] : [])
@@ -88,6 +92,13 @@ function getLanguages(record, torrentInfo, fileInfo) {
     languages = ['dubbed'];
   }
   return mapLanguages(languages);
+}
+
+function isPolishRelease(record) {
+  // parse-torrent-title only catches explicit tags, so additionally check
+  // weaker Polish signals (release groups, MULTi context, diacritics, etc.)
+  return [record.torrent.title, record.title]
+      .some(title => detectPolishRelease(title, { provider: record.torrent.provider }).isPolish);
 }
 
 function joinDetailParts(parts, prefix = '', delimiter = ' ') {

--- a/addon/package.json
+++ b/addon/package.json
@@ -4,7 +4,8 @@
   "exports": "./index.js",
   "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "author": "TheBeastLT <pauliox@beyond.lt>",
   "license": "MIT",

--- a/addon/test/fixtures/polishReleases.json
+++ b/addon/test/fixtures/polishReleases.json
@@ -1,0 +1,149 @@
+{
+  "positive": [
+    {
+      "name": "Quarantine [2008] [DVDRiP.XviD-M14CH0] [Lektor PL] [Arx]",
+      "expectedConfidence": "high",
+      "expectedTags": { "lektor": true }
+    },
+    {
+      "name": "The.Mandalorian.S01E06.POLISH.WEBRip.x264-FLAME",
+      "expectedConfidence": "high"
+    },
+    {
+      "name": "Bukmacher.Bookie.E02E07.MULTi.1080p.AMZN.WEB-DL.H264.DDP5.1.Atmos-K83.Lektor.PL",
+      "expectedConfidence": "high",
+      "expectedTags": { "lektor": true, "multi": true }
+    },
+    {
+      "name": "Avatar.2009.PL.1080p.BluRay.x264-DSiTE",
+      "expectedConfidence": "high"
+    },
+    {
+      "name": "Shrek.2001.PLDUB.1080p.BluRay.x264",
+      "expectedConfidence": "high",
+      "expectedTags": { "dubbing": true }
+    },
+    {
+      "name": "Wladca.Pierscieni.Druzyna.Pierscienia.2001.MULTi.2160p.UHD.BluRay.Remux-B89",
+      "expectedConfidence": "medium",
+      "expectedTags": { "multi": true }
+    },
+    {
+      "name": "Diuna.Czesc.Druga.2024.MULTi.1080p.BluRay.x264-KiT",
+      "expectedConfidence": "medium",
+      "expectedTags": { "multi": true }
+    },
+    {
+      "name": "Kler.2018.PL.1080p.WEB-DL.x264-PSiG",
+      "expectedConfidence": "high"
+    },
+    {
+      "name": "Znachor.2023.1080p.NF.WEB-DL.DDP5.1.x264.Napisy.PL",
+      "expectedConfidence": "high",
+      "expectedTags": { "napisy": true }
+    },
+    {
+      "name": "Kraina.Lodu.2013.Dubbing.PL.720p.BluRay",
+      "expectedConfidence": "high",
+      "expectedTags": { "dubbing": true }
+    },
+    {
+      "name": "Chłopi.2023.1080p.WEB-DL.H264",
+      "expectedConfidence": "medium"
+    },
+    {
+      "name": "Gra.o.Tron.Sezon.1.PL.480p.DVDRip",
+      "expectedConfidence": "high"
+    },
+    {
+      "name": "Oppenheimer.2023.MULTi.2160p.www.electro-torrent.pl",
+      "expectedConfidence": "high",
+      "expectedTags": { "multi": true }
+    },
+    {
+      "name": "[Devil-Torrents.pl] Vaiana 2 2024 MULTI 2160p WEB-DL",
+      "expectedConfidence": "high",
+      "expectedTags": { "multi": true }
+    },
+    {
+      "name": "Akademia.Pana.Kleksa.2023.PL.DUB.1080p.WEB-DL",
+      "expectedConfidence": "high",
+      "expectedTags": { "dubbing": true }
+    },
+    {
+      "name": "Dune.Part.Two.2024.MULTi.2160p.UHD.BluRay.x265",
+      "provider": "BestTorrents",
+      "expectedConfidence": "medium",
+      "expectedTags": { "multi": true }
+    },
+    {
+      "name": "Ostatnia.Rodzina.2016.Lektor.IVO.1080p.WEB-DL",
+      "expectedConfidence": "high",
+      "expectedTags": { "lektor": true }
+    },
+    {
+      "name": "Wonka.2023.MULTi.1080p.PLSUB.WEB-DL",
+      "expectedConfidence": "high",
+      "expectedTags": { "napisy": true, "multi": true }
+    },
+    {
+      "name": "Cały.Film.Po.Polsku.2021.720p",
+      "expectedConfidence": "high"
+    },
+    {
+      "name": "Listy.do.M.5.2022.PL.1080p.WEB-DL.x264-K83",
+      "expectedConfidence": "high"
+    }
+  ],
+  "negative": [
+    {
+      "name": "Deadpool.3.2024.MULTi.1080p.WEB.H264-FLUX",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "The.Matrix.1999.1080p.BluRay.x264-RARBG",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "Polish Wedding (1998) 1080p (moviesbyrizzo upl).mp4",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "La.Casa.De.Papel.S01.SPANISH.1080p.NF.WEB-DL",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "Kurtlar.Vadisi.Pusu.Sezon.1.TURKISH.480p",
+      "expectedConfidence": "low"
+    },
+    {
+      "name": "Movie.Title.2023.DUBBED.720p.WEB",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "Knight.Rider.S01.KITT.Special.1080p",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "Multi.Facial.1995.720p.WEB",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "Señora.Acero.S01E01.SPANISH.720p",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "Inception.2010.1080p.BluRay.x264-SPARKS",
+      "provider": "BestTorrents",
+      "expectedConfidence": "low"
+    },
+    {
+      "name": "Explosion.Imminent.2023.1080p.WEB",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "www.UIndex.pl - The.Movie.2023.1080p.WEB",
+      "expectedConfidence": "low"
+    }
+  ]
+}

--- a/addon/test/fixtures/polishReleases.json
+++ b/addon/test/fixtures/polishReleases.json
@@ -93,6 +93,40 @@
     {
       "name": "Listy.do.M.5.2022.PL.1080p.WEB-DL.x264-K83",
       "expectedConfidence": "high"
+    },
+    {
+      "name": "Furiosa.A.Mad.Max.Saga.2024.MULTi.2160p.WEB-DL.x265-LTS",
+      "expectedConfidence": "medium",
+      "expectedTags": { "multi": true }
+    },
+    {
+      "name": "Shogun.S01E05.MULTi.1080p.AMZN.WEB-DL.H264-ANONiM",
+      "expectedConfidence": "medium",
+      "expectedTags": { "multi": true }
+    },
+    {
+      "name": "Bridgerton.S03.LektorPL.1080p.NF.WEB-DL",
+      "expectedConfidence": "high",
+      "expectedTags": { "lektor": true }
+    },
+    {
+      "name": "Vaiana.2.2024.DUBBPL.720p.WEB-DL",
+      "expectedConfidence": "high",
+      "expectedTags": { "dubbing": true }
+    },
+    {
+      "name": "Glina.S01.Odc.1-13.PL.480p.DVDRip.Paczka",
+      "expectedConfidence": "high"
+    },
+    {
+      "name": "Twisters.2024.MULTi.1080p.WEB.x264-spajk85",
+      "expectedConfidence": "medium",
+      "expectedTags": { "multi": true }
+    },
+    {
+      "name": "Gladiator.II.2024.1080p.WEB-DL.Napisy.NapiProjekt",
+      "expectedConfidence": "high",
+      "expectedTags": { "napisy": true }
     }
   ],
   "negative": [
@@ -143,6 +177,14 @@
     },
     {
       "name": "www.UIndex.pl - The.Movie.2023.1080p.WEB",
+      "expectedConfidence": "low"
+    },
+    {
+      "name": "Dune.Part.Two.2024.MULTi.1080p.WEB.H264-FLAME",
+      "expectedConfidence": "none"
+    },
+    {
+      "name": "Nobody.2.2025.1080p.WEB.H264-LTS",
       "expectedConfidence": "low"
     }
   ]

--- a/addon/test/polishDetection.test.js
+++ b/addon/test/polishDetection.test.js
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { detectPolishRelease, Confidence } from '../lib/polishDetection.js';
+
+const fixtures = JSON.parse(readFileSync(new URL('./fixtures/polishReleases.json', import.meta.url)));
+
+test('detects Polish releases', async t => {
+  for (const fixture of fixtures.positive) {
+    await t.test(fixture.name, () => {
+      const result = detectPolishRelease(fixture.name, { provider: fixture.provider });
+      assert.equal(result.isPolish, true, `expected Polish, signals: ${result.signals}`);
+      assert.equal(result.confidence, fixture.expectedConfidence, `signals: ${result.signals}`);
+      for (const [tag, expected] of Object.entries(fixture.expectedTags || {})) {
+        assert.equal(result.tags[tag], expected, `expected tag ${tag}=${expected}`);
+      }
+    });
+  }
+});
+
+test('does not flag non-Polish releases', async t => {
+  for (const fixture of fixtures.negative) {
+    await t.test(fixture.name, () => {
+      const result = detectPolishRelease(fixture.name, { provider: fixture.provider });
+      assert.equal(result.isPolish, false, `expected not Polish, signals: ${result.signals}`);
+      assert.equal(result.confidence, fixture.expectedConfidence, `signals: ${result.signals}`);
+    });
+  }
+});
+
+test('handles empty input', () => {
+  const result = detectPolishRelease(undefined);
+  assert.equal(result.isPolish, false);
+  assert.equal(result.confidence, Confidence.NONE);
+  assert.deepEqual(result.signals, []);
+});
+
+test('reports matched signals and score', () => {
+  const result = detectPolishRelease('Kler.2018.PL.1080p.WEB-DL.x264-PSiG');
+  assert.ok(result.signals.includes('language-tag'));
+  assert.ok(result.signals.includes('release-group'));
+  assert.ok(result.score >= 4);
+});

--- a/addon/test/streamInfo.test.js
+++ b/addon/test/streamInfo.test.js
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// repository.js instantiates Sequelize on import, so a placeholder is needed
+// to test stream conversion without a real database connection.
+process.env.DATABASE_URI = process.env.DATABASE_URI || 'postgres://localhost:5432/torrentio';
+const { toStreamInfo } = await import('../lib/streamInfo.js');
+
+function movieRecord(title, provider = '1337x') {
+  return {
+    title: `${title}.mkv`,
+    size: 12000000000,
+    fileIndex: null,
+    imdbId: 'tt0000001',
+    torrent: {
+      title: title,
+      provider: provider,
+      seeders: 50,
+      size: 12000000000,
+      type: 'movie',
+      trackers: 'udp://tracker.example.org:1337/announce'
+    },
+    infoHash: '1234567890123456789012345678901234567890'
+  };
+}
+
+test('marks Polish MULTi release from a Polish group with the Polish flag', () => {
+  const stream = toStreamInfo(movieRecord('Diuna.Czesc.Druga.2024.MULTi.1080p.BluRay.x264-KiT'));
+  assert.ok(stream.title.includes('🇵🇱'), `title should contain Polish flag:\n${stream.title}`);
+});
+
+test('marks MULTi release from a Polish provider with the Polish flag', () => {
+  const stream = toStreamInfo(movieRecord('Dune.Part.Two.2024.MULTi.2160p.UHD.BluRay.x265', 'BestTorrents'));
+  assert.ok(stream.title.includes('🇵🇱'), `title should contain Polish flag:\n${stream.title}`);
+});
+
+test('does not duplicate the Polish flag when parse-torrent-title already detects it', () => {
+  const stream = toStreamInfo(movieRecord('Znachor.2023.1080p.NF.WEB-DL.Lektor.PL'));
+  const flagCount = stream.title.split('🇵🇱').length - 1;
+  assert.equal(flagCount, 1, `title should contain exactly one Polish flag:\n${stream.title}`);
+});
+
+test('does not mark generic MULTi releases with the Polish flag', () => {
+  const stream = toStreamInfo(movieRecord('Deadpool.3.2024.MULTi.1080p.WEB.H264-FLUX'));
+  assert.ok(!stream.title.includes('🇵🇱'), `title should not contain Polish flag:\n${stream.title}`);
+});
+
+test('does not mark plain English releases with the Polish flag', () => {
+  const stream = toStreamInfo(movieRecord('The.Matrix.1999.1080p.BluRay.x264-RARBG'));
+  assert.ok(!stream.title.includes('🇵🇱'), `title should not contain Polish flag:\n${stream.title}`);
+});


### PR DESCRIPTION
## Why

Follow-up to #359. A lot of Polish releases on general trackers (1337x, TPB, TorrentGalaxy) and Polish MULTi releases are not tagged `PL`/`POLISH`, so `parse-torrent-title` does not report `polish` for them. As a result they don't get the 🇵🇱 flag in stream titles and are not prioritized when the user selects Polish as their priority language. The most common complaint in the issue thread is MULTi releases with Polish audio not being recognized as Polish.

## What

- New dependency-free module `addon/lib/polishDetection.js` that scores a release/file name against multiple signals (explicit tags like `Lektor PL`/`Dubbing PL`/`Napisy PL`, Polish tracker watermarks, letters unique to the Polish alphabet, a curated list of Polish release groups, `*.pl` domains, provider origin) and maps the sum to a confidence level (`none`/`low`/`medium`/`high`) plus tags (`lektor`/`dubbing`/`napisy`/`multi`).
- `MULTi` alone is **not** treated as a Polish signal — it only adds corroboration when another weak Polish signal is present, which keeps false positives down (e.g. `Deadpool.3.2024.MULTi-FLUX` stays unflagged, while `Diuna.Czesc.Druga.2024.MULTi-KiT` is detected).
- Minimal integration: `getLanguages()` in `addon/lib/streamInfo.js` appends `polish` when detection confidence is at least `medium`, so the existing 🇵🇱 labeling, language sorting and filtering work for these releases. No scraper, database or API changes.
- Offline tests via the built-in `node:test` runner (no new dependencies): 41 tests against a fixture corpus of real-world Polish and non-Polish release names, including false-positive traps ("Polish Wedding", Turkish `Sezon`, `Multi.Facial`, `www.*.pl` watermarks). Run with `npm test` in `addon/`.
- Docs in `addon/docs/polish-detection.md` (signal table, thresholds, how to extend the release-group list).

## Notes

- The signal lists are intentionally conservative and easy to extend.
- The module is self-contained so it can be reused by other projects if you prefer it living elsewhere — happy to adjust thresholds or move the integration point if you have a preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)